### PR TITLE
Add `git fetch`

### DIFF
--- a/shared/clone.go
+++ b/shared/clone.go
@@ -90,6 +90,14 @@ func Clone(repoName string, baseBranchName string, headBranchName string) {
 			}
 		}
 
+		err = gitRepo.Fetch(&git.FetchOptions{
+			RemoteName: "upstream",
+			Force:      true,
+		})
+		if err != nil {
+			log.Fatalf("could not fetch repo remote: %v", err)
+		}
+
 		err = gitTree.Checkout(&git.CheckoutOptions{
 			Branch: plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", baseBranchName)),
 			Force:  true,


### PR DESCRIPTION
This PR adds a `git fetch` before checking out branches in repos that already exist on the filesystem.

Closes #13